### PR TITLE
avoid write to close channel

### DIFF
--- a/pkg/server/sotw/v3/xds.go
+++ b/pkg/server/sotw/v3/xds.go
@@ -45,6 +45,10 @@ func (s *server) process(str stream.Stream, reqCh chan *discovery.DiscoveryReque
 	// s.ctx.Done()
 	sw.watches.recompute(s.ctx, reqCh)
 
+	if s.opts.Ordered {
+		return s.processADS(&sw, reqCh, defaultTypeURL)
+	}
+
 	for {
 		// The list of select cases looks like this:
 		// 0: <- ctx.Done


### PR DESCRIPTION
This change avoids writing to the closed channel here
```
if s.opts.Ordered {
					// send our first request on the stream again so it doesn't get
					// lost in processing on the new control loop
					// There's a risk (albeit very limited) that we'd end up handling requests in the wrong order here.
					// If envoy is using ADS for endpoints, and clusters are added in short sequence,
					// the following request might include a new cluster and be discarded as the previous one will be handled after.
					go func() {
						reqCh <- req
					}()

					// Trigger a different code path specifically for ADS.
					// We want resource ordering so things don't get sent before they should.
					// This is a blocking call and will exit the process function
					// on successful completion.
					return s.processADS(&sw, reqCh, defaultTypeURL)
				}
```

Instead of doing this weird dance of inserting the first request again to the request channel we just run `s.processADS(&sw, reqCh, defaultTypeURL)` immediately.

We assume this was done on the first channel to support ADS and non-ADS connections on the same server. Since we don't care about non-ADS case, we can just immediately launch `processADS` and avoid rewriting the first request to the channel