### PR TITLE
chore(sync): checkout repository after sync

### DIFF
--- a/.github/workflows/sync-with-upstream.yaml
+++ b/.github/workflows/sync-with-upstream.yaml
@@ -49,12 +49,10 @@ jobs:
     - name: No new commits
       if: steps.sync.outputs.has_new_commits == 'false'
       run: echo "There were no new commits."
-    - name: Refresh repository
-      id: refresh
+    - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
       if: steps.sync.outputs.has_new_commits == 'true'
-      shell: bash
-      run: |
-        git fetch --all --tags
+      with:
+        fetch-depth: 0
     - name: Get new version tag
       id: new-version-tag
       if: steps.sync.outputs.has_new_commits == 'true'


### PR DESCRIPTION
The action that syncs with upstream removes some metadata from the repo. Checking it out again helps https://github.com/lukidzi/go-control-plane/actions/runs/12158561974/job/33906767932