### PR TITLE
chore(sync): get only tags with specific format

### DIFF
--- a/.github/scripts/get-version-tags.sh
+++ b/.github/scripts/get-version-tags.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-current_tag=$(git tag --list --merged origin/release --sort=-creatordate | head -n 1)
-main_tag=$(git tag --list --merged origin/main --sort=-creatordate | head -n 1)
+current_tag=$(git tag --list 'v[0-9].[0-9]*.[0-9]*' --merged origin/release --sort=-creatordate | head -n 1)
+main_tag=$(git tag --list 'v[0-9].[0-9]*.[0-9]*' --merged origin/main --sort=-creatordate | head -n 1)
 
 # Remove the prefix `v` and `-kong-*` suffix for comparison
 released_tag="${current_tag%-kong-*}"


### PR DESCRIPTION
seems that go-control-plane has now different types of tags