### PR TITLE
fix(ads): check if channel is closed

### DIFF
--- a/envoy/go.sum
+++ b/envoy/go.sum
@@ -4,8 +4,8 @@ github.com/cncf/xds/go v0.0.0-20240723142845-024c85f92f20 h1:N+3sFI5GUjRKBi+i0Tx
 github.com/cncf/xds/go v0.0.0-20240723142845-024c85f92f20/go.mod h1:W+zGtBO5Y1IgJhy4+A9GOqVhqLpfZi+vwmdNXUehLA8=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/envoyproxy/go-control-plane v0.13.3 h1:F2vYcSF8iRNhfvhZQRZ5Dvuyu0TpXazE9+h53TzkvA4=
-github.com/envoyproxy/go-control-plane v0.13.3/go.mod h1:uhvHSBAMSvy2Y+CuAYfByIRH19zcdir1rgmMzKUo3eA=
+github.com/envoyproxy/go-control-plane v0.13.4 h1:zEqyPVyku6IvWCFwux4x9RxkLOMUL+1vC9xUFv5l2/M=
+github.com/envoyproxy/go-control-plane v0.13.4/go.mod h1:kDfuBlDVsSj2MjrLEtRWtHlsWIFcGyB2RMO44Dc5GZA=
 github.com/envoyproxy/protoc-gen-validate v1.1.0 h1:tntQDh69XqOCOZsDz0lVJQez/2L6Uu2PdjCQwWCJ3bM=
 github.com/envoyproxy/protoc-gen-validate v1.1.0/go.mod h1:sXRDRVmzEbkM7CVcM06s9shE/m23dg3wzjl0UWqJ2q4=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=

--- a/examples/dyplomat/go.mod
+++ b/examples/dyplomat/go.mod
@@ -9,7 +9,7 @@ replace (
 )
 
 require (
-	github.com/envoyproxy/go-control-plane v0.13.3
+	github.com/envoyproxy/go-control-plane v0.13.4
 	github.com/envoyproxy/go-control-plane/envoy v1.32.3
 	google.golang.org/grpc v1.69.2
 	gopkg.in/yaml.v2 v2.4.0

--- a/pkg/cache/v3/simple.go
+++ b/pkg/cache/v3/simple.go
@@ -489,6 +489,15 @@ func (cache *snapshotCache) respond(ctx context.Context, request *Request, value
 	cache.log.Debugf("respond %s%v version %q with version %q", request.GetTypeUrl(), request.GetResourceNames(), request.GetVersionInfo(), version)
 
 	select {
+	case _, ok := <-value:
+		if !ok {
+			cache.log.Debugf("ADS mode: channel is closed %s%v", request.GetTypeUrl(), request.GetResourceNames())
+			return nil
+		}
+	default:
+	}
+
+	select {
 	case value <- createResponse(ctx, request, resources, version, heartbeat):
 		return nil
 	case <-ctx.Done():


### PR DESCRIPTION
We have observed that sometimes writing to the channel happens when the channel is already closed. This issue is related to [#1023](https://github.com/envoyproxy/go-control-plane/issues/1023).

Upon reviewing the code, I found that the `value` channel can be created by one goroutine, while a different goroutine handles sending data on this channel. The first goroutine depends on the existence of the stream and requests, while the second one is triggered from `SetSnapshot`, which operates with a different context than the server.

There appears to be a race condition where the stream is canceled, and resources start to be cleaned up, while the context in `SetSnapshot` might cancel later, leading to writing on a closed channel.

This is not a complete fix but should prevent the panic. We should aim to fix this by possibly keeping the context within the watch and checking for its cancellation, or other?